### PR TITLE
pgo/env: Account for .exe extensions during path resolution

### DIFF
--- a/src/pgo/env.rs
+++ b/src/pgo/env.rs
@@ -23,8 +23,18 @@ pub fn find_pgo_env() -> anyhow::Result<PgoEnv> {
         });
     }
 
+    libpath.set_file_name("llvm-profdata.exe");
+
+    if libpath.exists() {
+        return Ok(PgoEnv {
+            llvm_profdata: libpath,
+        });
+    }
+
     // Try to find `llvm-profdata` directly in PATH
-    if let Ok(llvm_profdata) = resolve_binary(Path::new("llvm-profdata")) {
+    if let Ok(llvm_profdata) = resolve_binary(Path::new("llvm-profdata"))
+        .or_else(|_| resolve_binary(Path::new("llvm-profdata.exe")))
+    {
         log::warn!(
             "llvm-profdata was resolved from PATH. \
 Make sure that its version is compatible with rustc! If not, run `{}`.",


### PR DESCRIPTION
Currently cargo-pgo does not work out of the box on Windows, because
llvm-tools-preview binaries have .exe extensions. This commit extends
find_pgo_env to look up llvm-profdata with .exe extension in case one
without it is not available.

I have verified manually that renaming `llvm-profdata.exe` to `llvm-profdata` manually works with current `main`. `bolt/env` probably has the same issue on Windows, but I didn't look into that. Should we tackle BOLT in this PR as well?
By the way, thanks for this library - it looks very neat!