### PR TITLE
Update bolt link flags to `-keep_relocs` on MacOS

### DIFF
--- a/src/bolt/mod.rs
+++ b/src/bolt/mod.rs
@@ -12,6 +12,12 @@ pub fn llvm_bolt_install_hint() -> &'static str {
     "Build LLVM with BOLT and add its `bin` directory to PATH."
 }
 
+#[cfg(target_os = "macos")]
+fn bolt_common_rustflags() -> &'static str {
+    "-C link-args=-Wl,-keep_relocs"
+}
+
+#[cfg(not(target_os = "macos"))]
 fn bolt_common_rustflags() -> &'static str {
     "-C link-args=-Wl,-q"
 }


### PR DESCRIPTION
MacOS does not have `-q` or `--emit-relocs` instead it has `-keep_relocs`