### PR TITLE
Respect `--target-dir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Dev
+## Fixes
+- Respect the `--target-dir` cargo argument and improve parsing of cargo arguments in general.
+
 # 0.2.4 (16. 1. 2023)
 ## Fixes
 - Do not close `stdin` when executing `cargo pgo run` ([#28](https://github.com/Kobzol/cargo-pgo/issues/28)).

--- a/src/bolt/instrument.rs
+++ b/src/bolt/instrument.rs
@@ -34,6 +34,12 @@ pub struct BoltInstrumentArgs {
     cargo_args: Vec<String>,
 }
 
+impl BoltInstrumentArgs {
+    pub fn cargo_args(&self) -> &[String] {
+        &self.cargo_args
+    }
+}
+
 pub fn bolt_instrument(ctx: CargoContext, args: BoltInstrumentArgs) -> anyhow::Result<()> {
     let bolt_dir = ctx.get_bolt_directory()?;
     let bolt_env = find_bolt_env()?;

--- a/src/bolt/optimize.rs
+++ b/src/bolt/optimize.rs
@@ -32,6 +32,12 @@ pub struct BoltOptimizeArgs {
     cargo_args: Vec<String>,
 }
 
+impl BoltOptimizeArgs {
+    pub fn cargo_args(&self) -> &[String] {
+        &self.cargo_args
+    }
+}
+
 pub fn bolt_optimize(ctx: CargoContext, args: BoltOptimizeArgs) -> anyhow::Result<()> {
     let bolt_dir = ctx.get_bolt_directory()?;
     let bolt_env = find_bolt_env()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,10 +58,38 @@ enum BoltArgs {
     Optimize(BoltOptimizeArgs),
 }
 
+impl BoltArgs {
+    fn cargo_args(&self) -> &[String] {
+        match self {
+            BoltArgs::Build(args) => args.cargo_args(),
+            BoltArgs::Optimize(args) => args.cargo_args(),
+        }
+    }
+}
+
+impl Args {
+    fn cargo_args(&self) -> &[String] {
+        match self {
+            Args::Pgo(args) => match args {
+                Subcommand::Info => &[],
+                Subcommand::Instrument(args) => args.cargo_args(),
+                Subcommand::Build(args)
+                | Subcommand::Run(args)
+                | Subcommand::Test(args)
+                | Subcommand::Bench(args) => args.cargo_args(),
+                Subcommand::Optimize(args) => args.cargo_args(),
+                Subcommand::Bolt(args) => args.cargo_args(),
+                Subcommand::Clean => &[],
+            },
+        }
+    }
+}
+
 fn run() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let ctx = get_cargo_ctx()?;
+    let cargo_args = args.cargo_args();
+    let ctx = get_cargo_ctx(cargo_args)?;
 
     let Args::Pgo(args) = args;
     match args {

--- a/src/pgo/instrument.rs
+++ b/src/pgo/instrument.rs
@@ -22,6 +22,12 @@ pub struct PgoInstrumentArgs {
     cargo_args: Vec<String>,
 }
 
+impl PgoInstrumentArgs {
+    pub fn cargo_args(&self) -> &[String] {
+        &self.cargo_args
+    }
+}
+
 #[derive(clap::Parser, Debug)]
 #[clap(trailing_var_arg(true))]
 pub struct PgoInstrumentShortcutArgs {
@@ -31,6 +37,12 @@ pub struct PgoInstrumentShortcutArgs {
 
     /// Additional arguments that will be passed to the executed `cargo` command.
     cargo_args: Vec<String>,
+}
+
+impl PgoInstrumentShortcutArgs {
+    pub fn cargo_args(&self) -> &[String] {
+        &self.cargo_args
+    }
 }
 
 impl PgoInstrumentShortcutArgs {

--- a/src/pgo/optimize.rs
+++ b/src/pgo/optimize.rs
@@ -30,6 +30,12 @@ pub struct PgoOptimizeArgs {
     cargo_args: Vec<String>,
 }
 
+impl PgoOptimizeArgs {
+    pub fn cargo_args(&self) -> &[String] {
+        &self.cargo_args
+    }
+}
+
 /// Merges PGO profiles and creates RUSTFLAGS that use them.
 pub fn prepare_pgo_optimization_flags(pgo_env: &PgoEnv, pgo_dir: &Path) -> anyhow::Result<String> {
     let stats = gather_pgo_profile_stats(pgo_dir)?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,3 +1,4 @@
+use crate::build::parse_cargo_args;
 use crate::ensure_directory;
 use std::path::{Path, PathBuf};
 
@@ -22,12 +23,18 @@ impl CargoContext {
 }
 
 /// Finds Cargo metadata from the current directory.
-pub fn get_cargo_ctx() -> anyhow::Result<CargoContext> {
-    let cmd = cargo_metadata::MetadataCommand::new();
-    let metadata = cmd
-        .exec()
-        .map_err(|error| anyhow::anyhow!("Cannot get cargo metadata: {:?}", error))?;
-    Ok(CargoContext {
-        target_directory: metadata.target_directory.into_std_path_buf(),
-    })
+pub fn get_cargo_ctx(cargo_args: &[String]) -> anyhow::Result<CargoContext> {
+    let cargo_args = parse_cargo_args(cargo_args.to_vec());
+    let target_directory = match cargo_args.target_dir {
+        Some(dir) => dir,
+        None => {
+            let cmd = cargo_metadata::MetadataCommand::new();
+            let metadata = cmd
+                .exec()
+                .map_err(|error| anyhow::anyhow!("Cannot get cargo metadata: {:?}", error))?;
+            metadata.target_directory.into_std_path_buf()
+        }
+    };
+
+    Ok(CargoContext { target_directory })
 }


### PR DESCRIPTION
Improves handling of Cargo arguments and respects `--target-dir`, which was previously ignored.