### PR TITLE
Respect binary user arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Dev
 ## Fixes
 - Respect the `--profile` cargo argument.
+- Do not filter or modify `cargo pgo run` arguments passed to the executed binary.
 
 # 0.2.5 (31. 12. 2023)
 ## Fixes

--- a/src/build.rs
+++ b/src/build.rs
@@ -141,6 +141,12 @@ pub fn parse_cargo_args(cargo_args: Vec<String>) -> CargoArgs {
     let mut iterator = cargo_args.into_iter();
     while let Some(arg) = iterator.next() {
         match arg.as_str() {
+            "--" => {
+                // After this, the user program arguments start, we should ignore these
+                args.filtered.push("--".to_string());
+                args.filtered.extend(iterator);
+                break;
+            }
             // Skip `--release`, we will pass it by ourselves.
             "--release" => {
                 log::warn!("Do not pass `--release` manually, it will be added automatically by `cargo-pgo`");

--- a/tests/integration/pgo.rs
+++ b/tests/integration/pgo.rs
@@ -245,3 +245,22 @@ fn test_respect_profile() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_respect_user_arg() -> anyhow::Result<()> {
+    let mut project = init_cargo_project()?;
+    project.file(
+        "src/main.rs",
+        r#"
+fn main() {
+    assert_eq!(std::env::args().skip(1).next().unwrap(), "--release".to_string());
+}
+"#,
+    );
+
+    project
+        .run(&["run", "--", "-v", "--", "--release"])?
+        .assert_ok();
+
+    Ok(())
+}


### PR DESCRIPTION
Before, if you executed `cargo run -- <cargo-args> -- <binary-args>`, `cargo-pgo` would modify `<binary-args>` (e.g. it would remove `--release`), which was wrong.