### PR TITLE
adding peepholes=all to bolt args

### DIFF
--- a/src/bolt/optimize.rs
+++ b/src/bolt/optimize.rs
@@ -146,6 +146,7 @@ fn optimize_binary(
         None => {
             args.extend(
                 [
+                    "--peepholes=all",
                     "-reorder-blocks=ext-tsp",
                     "-reorder-functions=hfsort",
                     "-split-functions=2",


### PR DESCRIPTION
using: https://android-developers.googleblog.com/2023/12/faster-rust-toolchains-for-android.html

i added --peepholes=all

testing it now on a large rust service..