### PR TITLE
Respect RUSTFLAGS set in `.cargo/config.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ rustc-demangle = "0.1"
 walkdir = "2.3.2"
 shellwords = "1.1.0"
 blake3 = "1.3.1"
+version_check = "0.9.4"
 
 [dev-dependencies]
 version_check = "0.9"

--- a/src/bolt/instrument.rs
+++ b/src/bolt/instrument.rs
@@ -9,7 +9,7 @@ use crate::bolt::cli::{add_bolt_args, BoltArgs};
 use crate::bolt::env::{find_bolt_env, BoltEnv};
 use crate::bolt::{bolt_pgo_rustflags, get_binary_profile_dir};
 use crate::build::{
-    cargo_command_with_flags, get_artifact_kind, handle_metadata_message, CargoCommand,
+    cargo_command_with_rustflags, get_artifact_kind, handle_metadata_message, CargoCommand,
 };
 use crate::cli::cli_format_path;
 use crate::utils::str::capitalize;
@@ -55,7 +55,7 @@ pub fn bolt_instrument(ctx: CargoContext, args: BoltInstrumentArgs) -> anyhow::R
     );
 
     let flags = bolt_pgo_rustflags(&ctx, args.with_pgo)?;
-    let mut cargo = cargo_command_with_flags(CargoCommand::Build, &flags, args.cargo_args)?;
+    let mut cargo = cargo_command_with_rustflags(CargoCommand::Build, flags, args.cargo_args)?;
 
     for message in cargo.messages() {
         let message = message?;

--- a/src/bolt/mod.rs
+++ b/src/bolt/mod.rs
@@ -12,19 +12,20 @@ pub fn llvm_bolt_install_hint() -> &'static str {
     "Build LLVM with BOLT and add its `bin` directory to PATH."
 }
 
-fn bolt_common_rustflags() -> &'static str {
-    "-C link-args=-Wl,-q"
+fn bolt_common_rustflags() -> Vec<String> {
+    vec!["-Clink-args=-Wl,-q".to_string()]
 }
 
-fn bolt_pgo_rustflags(ctx: &CargoContext, with_pgo: bool) -> anyhow::Result<String> {
+fn bolt_pgo_rustflags(ctx: &CargoContext, with_pgo: bool) -> anyhow::Result<Vec<String>> {
     let flags = match with_pgo {
         true => {
             let pgo_env = get_pgo_env()?;
             let pgo_dir = ctx.get_pgo_directory()?;
-            let flags = prepare_pgo_optimization_flags(&pgo_env, &pgo_dir)?;
-            format!("{} {}", flags, bolt_common_rustflags())
+            let mut flags = prepare_pgo_optimization_flags(&pgo_env, &pgo_dir)?;
+            flags.extend(bolt_common_rustflags());
+            flags
         }
-        false => bolt_common_rustflags().to_string(),
+        false => bolt_common_rustflags(),
     };
     Ok(flags)
 }

--- a/src/bolt/optimize.rs
+++ b/src/bolt/optimize.rs
@@ -11,7 +11,7 @@ use crate::bolt::cli::{add_bolt_args, BoltArgs};
 use crate::bolt::env::{find_bolt_env, BoltEnv};
 use crate::bolt::{bolt_pgo_rustflags, get_binary_profile_dir};
 use crate::build::{
-    cargo_command_with_flags, get_artifact_kind, handle_metadata_message, CargoCommand,
+    cargo_command_with_rustflags, get_artifact_kind, handle_metadata_message, CargoCommand,
 };
 use crate::cli::cli_format_path;
 use crate::run_command;
@@ -43,7 +43,7 @@ pub fn bolt_optimize(ctx: CargoContext, args: BoltOptimizeArgs) -> anyhow::Resul
     let bolt_env = find_bolt_env()?;
 
     let flags = bolt_pgo_rustflags(&ctx, args.with_pgo)?;
-    let mut cargo = cargo_command_with_flags(CargoCommand::Build, &flags, args.cargo_args)?;
+    let mut cargo = cargo_command_with_rustflags(CargoCommand::Build, flags, args.cargo_args)?;
 
     for message in cargo.messages() {
         let message = message?;

--- a/src/pgo/instrument.rs
+++ b/src/pgo/instrument.rs
@@ -1,5 +1,5 @@
 use crate::build::{
-    cargo_command_with_flags, get_artifact_kind, handle_metadata_message, CargoCommand,
+    cargo_command_with_rustflags, get_artifact_kind, handle_metadata_message, CargoCommand,
 };
 use crate::clear_directory;
 use crate::cli::cli_format_path;
@@ -73,8 +73,8 @@ pub fn pgo_instrument(ctx: CargoContext, args: PgoInstrumentArgs) -> anyhow::Res
         cli_format_path(pgo_dir.display())
     );
 
-    let flags = format!("-Cprofile-generate={}", pgo_dir.display());
-    let mut cargo = cargo_command_with_flags(args.command, &flags, args.cargo_args)?;
+    let flags = vec![format!("-Cprofile-generate={}", pgo_dir.display())];
+    let mut cargo = cargo_command_with_rustflags(args.command, flags, args.cargo_args)?;
 
     for message in cargo.messages() {
         let message = message?;

--- a/tests/integration/pgo.rs
+++ b/tests/integration/pgo.rs
@@ -280,8 +280,13 @@ fn test_respect_existing_rustflags() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// This only works for Rust 1.63+.
 #[test]
 fn test_respect_existing_rustflags_from_config() -> anyhow::Result<()> {
+    if !version_check::is_min_version("1.63.0").unwrap_or(false) {
+        return Ok(());
+    }
+
     let mut project = init_cargo_project()?;
     project.file(
         ".cargo/config.toml",

--- a/tests/integration/pgo.rs
+++ b/tests/integration/pgo.rs
@@ -264,3 +264,38 @@ fn main() {
 
     Ok(())
 }
+
+#[test]
+fn test_respect_existing_rustflags() -> anyhow::Result<()> {
+    let project = init_cargo_project()?;
+
+    let output = project
+        .cmd(&["build", "--", "-v"])
+        .env("RUSTFLAGS", "-Ctarget-cpu=native")
+        .run()?;
+    assert!(output.stderr().contains("-Ctarget-cpu=native"));
+    assert!(output.stderr().contains("-Cprofile-generate"));
+    output.assert_ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_respect_existing_rustflags_from_config() -> anyhow::Result<()> {
+    let mut project = init_cargo_project()?;
+    project.file(
+        ".cargo/config.toml",
+        r#"
+[build]
+rustflags = ["-Ctarget-cpu=native"]
+"#,
+    );
+
+    let output = project.cmd(&["build", "--", "-v"]).run()?;
+    println!("{}", output.stderr());
+    assert!(output.stderr().contains("-Ctarget-cpu=native"));
+    assert!(output.stderr().contains("-Cprofile-generate"));
+    output.assert_ok();
+
+    Ok(())
+}

--- a/tests/integration/utils/mod.rs
+++ b/tests/integration/utils/mod.rs
@@ -1,4 +1,5 @@
 use cargo_pgo::get_default_target;
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -14,6 +15,13 @@ pub struct CargoProject {
 impl CargoProject {
     pub fn run(&self, args: &[&str]) -> anyhow::Result<Output> {
         self.run_with_input(args, &[])
+    }
+
+    pub fn cmd(&self, args: &[&str]) -> Cmd {
+        Cmd::default()
+            .cwd(&self.dir)
+            .args(&["cargo", "pgo"])
+            .args(args)
     }
 
     pub fn run_with_input(&self, args: &[&str], stdin: &[u8]) -> anyhow::Result<Output> {
@@ -49,6 +57,7 @@ impl CargoProject {
 
     pub fn file<P: AsRef<Path>>(&mut self, path: P, code: &str) -> &mut Self {
         let path = self.path(path.as_ref());
+        std::fs::create_dir_all(path.parent().unwrap()).expect("Cannot create parent directory");
         std::fs::write(path, code).expect("Could not write project file");
         self
     }
@@ -92,6 +101,64 @@ impl Drop for CargoProject {
             // Do not delete the directory if an error has occurred
             let path = std::mem::replace(&mut self._tempdir, TempDir::new().unwrap()).into_path();
             eprintln!("Directory of failed test located at: {}", path.display());
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Cmd {
+    arguments: Vec<String>,
+    cwd: Option<PathBuf>,
+    stdin: Vec<u8>,
+    env: HashMap<String, String>,
+}
+
+impl Cmd {
+    pub fn run(self) -> anyhow::Result<Output> {
+        let mut command = Command::new(&self.arguments[0]);
+        for arg in &self.arguments[1..] {
+            command.arg(arg);
+        }
+        if let Some(cwd) = self.cwd {
+            command.current_dir(&cwd);
+        }
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        let path = std::env::var("PATH").unwrap_or_default();
+        let path = format!("{}:{}", cargo_pgo_target_dir().display(), path);
+
+        command.env("PATH", path);
+
+        for (key, value) in self.env {
+            command.env(key, value);
+        }
+
+        let mut child = command.spawn()?;
+        {
+            let mut child_stdin = child.stdin.take().unwrap();
+            child_stdin.write_all(&self.stdin)?;
+        }
+
+        let output = child.wait_with_output()?;
+        Ok(output)
+    }
+
+    pub fn args(mut self, args: &[&str]) -> Self {
+        self.arguments.extend(args.iter().map(|s| s.to_string()));
+        self
+    }
+
+    pub fn env(mut self, key: &str, value: &str) -> Self {
+        self.env.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    pub fn cwd(self, cwd: &Path) -> Self {
+        Self {
+            cwd: Some(cwd.to_path_buf()),
+            ..self
         }
     }
 }


### PR DESCRIPTION
This PR changes the way `cargo-pgo` sets RUSTFLAGS in order to not overwrite flags set in `.cargo/config.toml` file(s). It doesn't handle ENCODED_RUSTFLAGS, but hopefully this should resolve most of the use-cases of setting custom RUSTFLAGS.

Fixes: https://github.com/Kobzol/cargo-pgo/issues/49