### PR TITLE
Fix config args for `cargo pgo run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Dev
+## Fixes
+
+- Fix passing of `--config` Cargo argument when using `cargo pgo run`.
+
 # 0.2.7 (28. 3. 2024)
 ## Fixes
 

--- a/tests/integration/pgo.rs
+++ b/tests/integration/pgo.rs
@@ -304,3 +304,24 @@ rustflags = ["-Ctarget-cpu=native"]
 
     Ok(())
 }
+
+#[test]
+fn test_run_pass_args_to_cargo() -> anyhow::Result<()> {
+    let mut project = init_cargo_project()?;
+    project.file(
+        "src/main.rs",
+        r#"
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    assert_eq!(args.len(), 3);
+    assert_eq!(args[1], "arg-for-binary");
+    assert_eq!(args[2], "foo");
+}
+"#,
+    );
+    project
+        .run(&["run", "--", "-v", "--", "arg-for-binary", "foo"])?
+        .assert_ok();
+
+    Ok(())
+}


### PR DESCRIPTION
They need to be prepended, not appended to Cargo args.

Fixes: https://github.com/Kobzol/cargo-pgo/issues/53