### PR TITLE
chore: release v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.10](https://github.com/Kobzol/cargo-pgo/compare/v0.2.9...v0.2.10) - 2026-01-24
+
+### Fixed
+
+- fixup
+- fix beta clippy
+
+### Other
+
+- Reformat code
+- Update edition to 2024 and MSRV to 1.85.0
+- Specify in `help` that cargo args have to be passed after `--`
+- Better document `cargo pgo optimize` in the README
+- bump few crates to drop deps
+- use rustc_version instead of version_check: its almost good but missed host field
+- use profiles_dir
+- add ability to override pgo path
+- Replace OnceCell with OnceLock
 # Dev
 ## Changes
 - Better document that Cargo arguments have to be passed after `--` (https://github.com/Kobzol/cargo-pgo/pull/80).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.10](https://github.com/Kobzol/cargo-pgo/compare/v0.2.9...v0.2.10) - 2026-01-24
 
-### Fixed
-
-- fixup
-- fix beta clippy
-
-### Other
-
-- Reformat code
+### Changes
 - Update edition to 2024 and MSRV to 1.85.0
 - Specify in `help` that cargo args have to be passed after `--`
 - Better document `cargo pgo optimize` in the README
-- bump few crates to drop deps
-- use rustc_version instead of version_check: its almost good but missed host field
-- use profiles_dir
-- add ability to override pgo path
-- Replace OnceCell with OnceLock
-# Dev
-## Changes
-- Better document that Cargo arguments have to be passed after `--` (https://github.com/Kobzol/cargo-pgo/pull/80).
+- Add ability to override pgo path
+
+### Fixes
+- Use rustc_version instead of version_check: its almost good but missed host field
 
 # 0.2.9 (24. 1. 2025)
 ## Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgo"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgo"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2024"
 rust-version = "1.85.0"
 


### PR DESCRIPTION



## 🤖 New release

* `cargo-pgo`: 0.2.9 -> 0.2.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.10](https://github.com/Kobzol/cargo-pgo/compare/v0.2.9...v0.2.10) - 2026-01-24

### Fixed

- fixup
- fix beta clippy

### Other

- Reformat code
- Update edition to 2024 and MSRV to 1.85.0
- Specify in `help` that cargo args have to be passed after `--`
- Better document `cargo pgo optimize` in the README
- bump few crates to drop deps
- use rustc_version instead of version_check: its almost good but missed host field
- use profiles_dir
- add ability to override pgo path
- Replace OnceCell with OnceLock
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).