### PR TITLE
Add `--profiles-dir` argument to `cargo pgo bolt {build,optimize}`

### DIFF
--- a/src/bolt/instrument.rs
+++ b/src/bolt/instrument.rs
@@ -27,6 +27,10 @@ pub struct BoltInstrumentArgs {
     #[clap(long, action)]
     keep_profiles: bool,
 
+    /// Override the BOLT profile path.
+    #[clap(long)]
+    profiles_dir: Option<PathBuf>,
+
     #[clap(flatten)]
     bolt_args: BoltArgs,
     /// Additional arguments that will be passed to `cargo build`.
@@ -37,6 +41,10 @@ pub struct BoltInstrumentArgs {
 impl BoltInstrumentArgs {
     pub fn cargo_args(&self) -> &[String] {
         &self.cargo_args
+    }
+
+    pub fn profiles_dir(&self) -> &Option<PathBuf> {
+        &self.profiles_dir
     }
 }
 

--- a/src/bolt/optimize.rs
+++ b/src/bolt/optimize.rs
@@ -27,6 +27,9 @@ pub struct BoltOptimizeArgs {
     with_pgo: bool,
     #[clap(flatten)]
     bolt_args: BoltArgs,
+    /// Override the BOLT profile path.
+    #[clap(long)]
+    profiles_dir: Option<PathBuf>,
     /// Additional arguments that will be passed to `cargo build`.
     #[arg(last(true))]
     cargo_args: Vec<String>,
@@ -35,6 +38,10 @@ pub struct BoltOptimizeArgs {
 impl BoltOptimizeArgs {
     pub fn cargo_args(&self) -> &[String] {
         &self.cargo_args
+    }
+
+    pub fn profiles_dir(&self) -> &Option<PathBuf> {
+        &self.profiles_dir
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,13 @@ impl BoltArgs {
             BoltArgs::Optimize(args) => args.cargo_args(),
         }
     }
+
+    pub fn profiles_dir(&self) -> &Option<PathBuf> {
+        match self {
+            BoltArgs::Build(args) => args.profiles_dir(),
+            BoltArgs::Optimize(args) => args.profiles_dir(),
+        }
+    }
 }
 
 #[derive(clap::Parser, Debug)]
@@ -73,6 +80,9 @@ struct CleanArgs {
     /// Override the PGO profile directory.
     #[clap(long)]
     profiles_dir: Option<PathBuf>,
+    /// Override the BOLT profile directory.
+    #[clap(long)]
+    bolt_profiles_dir: Option<PathBuf>,
 }
 
 impl Args {
@@ -102,8 +112,26 @@ impl Args {
                 | Subcommand::Test(args)
                 | Subcommand::Bench(args) => args.profiles_dir().to_owned(),
                 Subcommand::Optimize(args) => args.profiles_dir().to_owned(),
+                Subcommand::Clean(CleanArgs { profiles_dir, .. }) => profiles_dir.to_owned(),
                 Subcommand::Bolt(..) => None,
-                Subcommand::Clean(CleanArgs { profiles_dir }) => profiles_dir.to_owned(),
+            },
+        }
+    }
+
+    fn bolt_profiles_dir(&self) -> Option<PathBuf> {
+        match self {
+            Args::Pgo(args) => match args {
+                Subcommand::Bolt(args) => args.profiles_dir().to_owned(),
+                Subcommand::Clean(CleanArgs {
+                    bolt_profiles_dir, ..
+                }) => bolt_profiles_dir.to_owned(),
+                Subcommand::Info
+                | Subcommand::Instrument(..)
+                | Subcommand::Build(..)
+                | Subcommand::Run(..)
+                | Subcommand::Test(..)
+                | Subcommand::Bench(..)
+                | Subcommand::Optimize(..) => None,
             },
         }
     }
@@ -114,7 +142,8 @@ fn run() -> anyhow::Result<()> {
 
     let cargo_args = args.cargo_args();
     let profiles_dir = args.profiles_dir();
-    let ctx = get_cargo_ctx(cargo_args, profiles_dir)?;
+    let bolt_profiles_dir = args.bolt_profiles_dir();
+    let ctx = get_cargo_ctx(cargo_args, profiles_dir, bolt_profiles_dir)?;
 
     let Args::Pgo(args) = args;
     match args {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4,12 +4,13 @@ use std::path::{Path, PathBuf};
 
 pub struct CargoContext {
     target_directory: PathBuf,
-    profiles_dir: Option<PathBuf>,
+    pgo_profiles_dir: Option<PathBuf>,
+    bolt_profiles_dir: Option<PathBuf>,
 }
 
 impl CargoContext {
     pub fn get_pgo_directory(&self) -> anyhow::Result<PathBuf> {
-        if let Some(profiles_dir) = &self.profiles_dir {
+        if let Some(profiles_dir) = &self.pgo_profiles_dir {
             Ok(profiles_dir.clone())
         } else {
             self.get_target_directory(Path::new("pgo-profiles"))
@@ -17,7 +18,11 @@ impl CargoContext {
     }
 
     pub fn get_bolt_directory(&self) -> anyhow::Result<PathBuf> {
-        self.get_target_directory(Path::new("bolt-profiles"))
+        if let Some(profiles_dir) = &self.bolt_profiles_dir {
+            Ok(profiles_dir.clone())
+        } else {
+            self.get_target_directory(Path::new("bolt-profiles"))
+        }
     }
 
     fn get_target_directory(&self, path: &Path) -> anyhow::Result<PathBuf> {
@@ -30,7 +35,8 @@ impl CargoContext {
 /// Finds Cargo metadata from the current directory.
 pub fn get_cargo_ctx(
     cargo_args: &[String],
-    profiles_dir: Option<PathBuf>,
+    pgo_profiles_dir: Option<PathBuf>,
+    bolt_profiles_dir: Option<PathBuf>,
 ) -> anyhow::Result<CargoContext> {
     let cargo_args = parse_cargo_args(cargo_args.to_vec());
     let target_directory = match cargo_args.target_dir {
@@ -46,6 +52,7 @@ pub fn get_cargo_ctx(
 
     Ok(CargoContext {
         target_directory,
-        profiles_dir,
+        pgo_profiles_dir,
+        bolt_profiles_dir,
     })
 }


### PR DESCRIPTION
This PR basically implements `get_bolt_directory` in such a way that the user can supply their own profiles directory.

To remain backwards compatible I did not rename `cargo pgo clean --profiles-dir` to `cargo pgo clean --pgo-profiles-dir`, but it adds a bit of an assymetry with the newly added `cargo pgo clean --bolt-profiles-dir` subcommand.