### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1](https://github.com/Kobzol/cargo-pgo/compare/v0.3.0...v0.3.1) - 2026-04-25
+
+### Other
+
+- Add `--profiles-dir` argument to cargo pgo bolt {build,optimize}
+
 ## [0.3.0](https://github.com/Kobzol/cargo-pgo/compare/v0.2.10...v0.3.0) - 2026-01-25
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgo"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85.0"
 


### PR DESCRIPTION



## 🤖 New release

* `cargo-pgo`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/Kobzol/cargo-pgo/compare/v0.3.0...v0.3.1) - 2026-04-25

### Other

- Add `--profiles-dir` argument to cargo pgo bolt {build,optimize}
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).